### PR TITLE
Added support for Firefox / generic browser API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Jambofy Chrome Extension
+# Jambofy Browser Extension
 
 ![Google Chrome](https://img.shields.io/badge/Google%20Chrome-4285F4?style=for-the-badge&logo=GoogleChrome&logoColor=white)
+![Mozilla Firefox](https://img.shields.io/badge/Mozilla%20Firefox-FF7139?style=for-the-badge&logo=Firefox&logoColor=white)
 ![Opera](https://img.shields.io/badge/Opera-FF1B2D?style=for-the-badge&logo=Opera&logoColor=white)
 
 ![Chrome Web Store Last Updated](https://img.shields.io/chrome-web-store/last-updated/ecbedadooalalcgolmfgpnmphhccegei)
@@ -12,18 +13,42 @@
   <img src="https://lh3.googleusercontent.com/Nw4bhfjeIqi9gXZXH1Jv9Qr7_oQb5ziM1r_yPh-PTZawSAan3M77cxazYB0CmR-nhlZIrAfrXB7JqXvcWJ4JkZK4=w640-h400-e365-rj-sc0x00ffffff" alt="Jambofy Image" width = "800" height="500" style="align-items=center; justify-content=center;" />
 </p>
 
-Programmed by [Liam](https://www.linkedin.com/in/liam-t-harrison/) 
+Programmed by [Liam](https://www.linkedin.com/in/liam-t-harrison/)
+
+Ported to Firebox/Safari by [Sander](https://www.linkedin.com/in/sandercvonk)
 
 Photoshopping and videos by [Peam](https://www.youtube.com/@Sopeamy)
 
-This extension was originally made as a submission for Jshlatt's Shark Tank Pitch Stream in late 2023. 
-<br />
-Link to video:
-https://youtu.be/H5iqrUr4uYk?si=b0lR5J_ZlHQQlp2p 
-<br />
-Link to extension store page:
-https://chromewebstore.google.com/detail/jambofy/ecbedadooalalcgolmfgpnmphhccegei 
-<br />
+This extension was originally made as a submission for Jshlatt's Shark Tank Pitch Stream in late 2023.
+
+## Links
+- Video: https://youtu.be/H5iqrUr4uYk?si=b0lR5J_ZlHQQlp2p
+- Chrome Web Store: https://chromewebstore.google.com/detail/jambofy/ecbedadooalalcgolmfgpnmphhccegei
+
+## Browser Compatibility
+
+### Chrome/Chromium-based browsers
+- Uses service worker background context
+- Available on [Chrome Web Store](https://chromewebstore.google.com/detail/jambofy/ecbedadooalalcgolmfgpnmphhccegei)
+
+### Firefox
+- Uses background scripts context
+- To install manually:
+  1. Download or clone this repository
+  2. Open Firefox and go to `about:debugging`
+  3. Click "This Firefox"
+  4. Click "Load Temporary Add-on"
+  5. Select the `manifest.json` file
+
+### Safari (Temporary - does not persist after quitting)
+- Supports both contexts, will use service worker by default
+- To install manually/temporarily:
+  1. Download or clone this repository
+  2. Open Safari's Settings->Developer menu
+  3. Under "Extensions", check "Allow unsigned extensions" and press "Add Temporary Extension..."
+  4. Select the folder that contains `manifest.json` and click "Open"
+  5. Open YouTube, and if prompted, allow access by clicking on the extension icon to the left of the address bar
+
+## Inspiration
 The idea for this extension was inspired by the MrBeastify extension:
-<br />
 https://chromewebstore.google.com/detail/youtube-mrbeastify/dbmaeobgdodeimjdjnkipbfhgeldnmeb

--- a/background.js
+++ b/background.js
@@ -1,5 +1,11 @@
 
-chrome.runtime.onMessage.addListener((data, sender, sendResponse) =>
+// Cross-browser compatibility
+const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
+
+// Handle both service worker and background script contexts
+const isServiceWorker = typeof importScripts === 'function';
+
+browserAPI.runtime.onMessage.addListener((data, sender, sendResponse) =>
 {
     const { prefs } = data
     switch (data.event)
@@ -18,12 +24,15 @@ chrome.runtime.onMessage.addListener((data, sender, sendResponse) =>
     }
 
     sendResponse({status: 'success'});
+    
+    // Indicate async response
+    return true;
 });
 
 const handleOnToggleCats = (prefs) =>
 {
     console.log("Toggle cats in background", prefs)
-    chrome.storage.local.set(prefs, () =>
+    browserAPI.storage.local.set(prefs, () =>
     {
         console.log("Toggle cats saved in local storage");
     });
@@ -32,7 +41,7 @@ const handleOnToggleCats = (prefs) =>
 const handleOnSwitchOpacity = (prefs) =>
 {
     console.log("prefs for opacity received: ", prefs)
-    chrome.storage.local.set(prefs, () =>
+    browserAPI.storage.local.set(prefs, () =>
     {
         console.log("Opacity saved in local storage");
     });
@@ -41,7 +50,7 @@ const handleOnSwitchOpacity = (prefs) =>
 const handleOnToggleText = (prefs) =>
 {
     console.log("Toggle text in background", prefs)
-    chrome.storage.local.set(prefs, () =>
+    browserAPI.storage.local.set(prefs, () =>
     {
         console.log("Toggle text saved in local storage");
     });

--- a/main.js
+++ b/main.js
@@ -1,5 +1,8 @@
 (() =>
     {
+        // Cross-browser compatibility
+        const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
+        
         const imageFilePath = "assets/images/";
         const numImages = 209;
         const flipExcludedCutoff = 204; //NOTE: this number represents the cutoff for where the non flippable images start
@@ -62,7 +65,7 @@
             }
         }
 
-        chrome.storage.local.get(["opacity", "toggledCats", "toggledText"], (result) =>
+        browserAPI.storage.local.get(["opacity", "toggledCats", "toggledText"], (result) =>
         {
             if(result.opacity)
             {
@@ -117,7 +120,7 @@
         });
 
         //Ensures that it updates whenever the user changes it
-        chrome.storage.onChanged.addListener((changes, areaName) =>
+        browserAPI.storage.onChanged.addListener((changes, areaName) =>
         {
             if(areaName === 'local')
             {
@@ -175,7 +178,7 @@
         //NOTE: The purpose of this function is to return the url of an image
         function getImageURL(index)
         {
-            return chrome.runtime.getURL(`${imageFilePath}${index}.png`);
+            return browserAPI.runtime.getURL(`${imageFilePath}${index}.png`);
         }
 
         //NOTE: The purpose of this function is to apply the thumbnail images to the thumbnails on YouTube.com

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,13 @@
   "name": "Jambofy",
   "version": "2.0.0",
   "description": "Improves boring YouTube thumbnails by adding Jambo and other cats.",
-  "host_permissions": [ "https://www.youtube.com/*"],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "jambofy@liamharrison.dev",
+      "strict_min_version": "109.0"
+    }
+  },
+  "host_permissions": ["https://www.youtube.com/*"],
   "content_scripts":
   [
     {
@@ -42,8 +48,8 @@
   },
   "background":
   {
-    "service_worker": "background.js",
-    "type": "module"
+    "scripts": ["background.js"],
+    "service_worker": "background.js"
   },
   "permissions":
   [

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,7 @@
 
+// Cross-browser compatibility
+const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
+
 //Elements:
 const opacityDropdown = document.getElementById("opacity");
 const toggleCatsDropdown = document.getElementById("toggleCats");
@@ -15,7 +18,7 @@ function ToggleCats()
             toggledCats : toggleCatsDropdown.value
         }
     console.log(toggleCatsDropdown.value);
-    chrome.runtime.sendMessage({event: 'onToggleCats', prefs})
+    browserAPI.runtime.sendMessage({event: 'onToggleCats', prefs})
     console.log("Sending toggleCats event");
 }
 
@@ -26,7 +29,7 @@ function SwitchCatOpacity()
             opacity: opacityDropdown.value
         }
     console.log(opacityDropdown.value);
-    chrome.runtime.sendMessage({event: 'onSwitchOpacity', prefs})
+    browserAPI.runtime.sendMessage({event: 'onSwitchOpacity', prefs})
     console.log("Sending switchOpacity event");
 }
 
@@ -37,12 +40,12 @@ function ToggleText()
             toggledText : toggleTextDropdown.value
         }
         console.log(toggleTextDropdown.value);
-    chrome.runtime.sendMessage({event: 'onToggleText', prefs})
+    browserAPI.runtime.sendMessage({event: 'onToggleText', prefs})
     console.log("Sending toggleText event");
 }
 
 //NOTE: Ensures that the opacity preferences will be saved
-chrome.storage.local.get(["opacity"], (result) =>
+browserAPI.storage.local.get(["opacity"], (result) =>
 {
     const { opacity } = result;
 
@@ -53,7 +56,7 @@ chrome.storage.local.get(["opacity"], (result) =>
 })
 
 //NOTE: Ensures that the toggle cats preferences will be saved
-chrome.storage.local.get(["toggledCats"], (result ) =>
+browserAPI.storage.local.get(["toggledCats"], (result ) =>
 {
     const { toggledCats } = result;
 
@@ -64,7 +67,7 @@ chrome.storage.local.get(["toggledCats"], (result ) =>
 })
 
 //NOTE: Ensures the the toggle text preferences will be saved
-chrome.storage.local.get(["toggledText"], (result) =>
+browserAPI.storage.local.get(["toggledText"], (result) =>
 {
     const { toggledText } = result;
 


### PR DESCRIPTION
Update chrome API usage to instead use a generic `browser` API, or `chrome` if not present; made some relevant README / text tweaks to reflect this change and developer mode install instructions as well.